### PR TITLE
Improved usability of module

### DIFF
--- a/README.org
+++ b/README.org
@@ -21,38 +21,42 @@ Here is an example of what it looks like in Mission Portal:
   - =path= must be a regular expression matching the fully qualified path to a file
   - =why=  should explain why the file being absent is important
 
-#+caption: Example Augments configuration
-#+begin_src json
-{
-  "variables": {
-    "delete_files:delete_files.files": {
-      "value": [
-        {
-          "path": "/tmp/virus",
-          "why": "This is just an example, but if there is a file called virus there, you'd want it deleted!"
-        },
-        {
-          "path": "/home/.*/.shosts",
-          "why": "These files list remote hosts and users for host based authentication. Deletion recommended by CIS CCE-84145-2."
-        },
-        {
-          "path": "/etc/cron.deny",
-          "why": "Deny should be default, use an explicit allow list in /etc/cron.allow instead."
-        }
-      ],
-      "comment": "Files and their required permissions"
-    }
-  }
-}
-#+end_src
+  #+caption: Example Augments configuration
+  #+begin_src json
+     {
+       "variables": {
+         "delete_files:delete_files.files": {
+           "comment": "Files and their required permissions",
+           "value": [
+             {
+               "why": "The file lists remote hosts and users that are trusted by the local system when using the rshd daemon and can allow unauthenticated access to the system. Reccomended by CIS  CCE-84145-2.",
+               "path": "/etc/hosts.equiv"
+             },
+             {
+               "why": "The file lists remote hosts and users that are trusted by the local system when using the rshd daemon and can allow unauthenticated access to the system. Reccomended by CIS  CCE-84145-2.",
+               "path": "/home/.*/.rhosts"
+             },
+             {
+               "why": "The file lists remote hosts and users that are trusted by the local system when using the rshd daemon and can allow unauthenticated access to the system. Reccomended by CIS  CCE-84145-2.",
+               "path": "/root/.rhosts"
+             }
+           ]
+         }
+       }
+     }
+  #+end_src
 
-** Testing that it works
+  *Notes:*
+  - Running with class =delete_files:DEBUG= or =default:DEBUG= define results in DEBUG reports from policy.
+  - A list or array of files is also supported.
+  - An array with filenames and dicts having =path=  and =why= keys is supported.
+  - Absence of =why= key is supported.
+  - A simple string is supported (but as indicated by DEBUG reports, likely a mis-configuration).
+  - Directories are *not* deleted.
 
-After adding the file paths you want deleted (via input or JSON) you can touch the files and see that they get deleted:
+* History
 
-#+begin_example
-$ sudo touch /tmp/virus /home/ubuntu/.shosts /etc/cron.deny && sudo cf-agent -KI
-    info: Deleted file '/tmp/virus'
-    info: Deleted file '/home/ubuntu/.shosts'
-    info: Deleted file '/etc/cron.deny'
-#+end_example
+- DEBUG reports added in version 2.0.0.
+- Support for simple list specification added in version 2.0.0.
+- Support for mixed data array specification added in version 2.0.0.
+- Support for absence of =why= key added in version 2.0.0.

--- a/cfbs.json
+++ b/cfbs.json
@@ -6,7 +6,7 @@
     "delete-files": {
         "description": "Allows you to specify a list of files you want deleted on hosts in your infrastructure. When this module is deployed as part of your policy set, every time CFEngine runs, it will check if those files exist, and delete them if they do.",
       "tags": ["management"],
-      "version": "1.0.0",
+      "version": "2.0.0",
       "by": "https://github.com/nickanderson",
       "repo": "https://github.com/nickanderson/cfengine-delete-files",
       "input": [

--- a/delete-files.cf
+++ b/delete-files.cf
@@ -10,12 +10,83 @@ bundle agent delete_files
 # - Directories are not deleted
 {
   vars:
+      # This could return:
+      # - "none" if not defined
+      # - "data array" if defined as a data array
+      # - "data object" if defined as an object which would be completely invalid specification
+      # - "policy slist" if defined as a list via CMDB
+      # - "policy string" if defined as a string via CMDB
+      "_files_var_type"
+        string => type( "files", "true" );
+
       # We pull the index from the files variable so that we can iterate over each file to manage it's mode
       "i" slist => getindices( files );
 
+      # If files is 'data array', we need to probe each element of the array for
+      # it's type in order to differentiate between those using the original
+      # structure that requires the 'why' key to be provided as an explanation
+      "_type[$(i)]"
+        string => type( "files[$(i)]", true ),
+        if => strcmp( "$(_files_var_type)", "data array" );
+
+
   files:
+      # Delete files that were specified as a list
       "$(files[$(i)][path])"
-      delete => default:tidy,
-      file_select => default:not_dir,
-      comment => "$(files[$(i)][why])";
+        delete => default:tidy,
+        file_select => default:not_dir,
+        if => strcmp( "$(_type[$(i)])", "policy slist" ),
+        comment => "No reasoning provided";
+
+      # Delete files that were specified as a string inside of a data array
+      "$(files[$(i)])"
+        delete => default:tidy,
+        file_select => default:not_dir,
+        if => and( strcmp( "$(_files_var_type)", "data array" ),
+                   strcmp( "$(_type[$(i)])", "data string" ) ),
+        comment => "No reasoning provided";
+
+      # Delete files when it's defined as a singluar string
+      # This is very plausibly the case of a mis-configuration
+      "$(files)"
+        delete => default:tidy,
+        file_select => default:not_dir,
+        if => strcmp( "$(_files_var_type)", "policy string" ),
+        comment => "No reasoning provided";
+
+      # Delete files that were specified in the structured specification but lack the 'why' key
+      "$(files[$(i)][path])"
+        delete => default:tidy,
+        file_select => default:not_dir,
+        if => not( isvariable( "files[$(i)][why]") ),
+        comment => "No reasoning provided";
+
+      # Delete files that were specified in the structured specification having the 'why' key
+      "$(files[$(i)][path])"
+        delete => default:tidy,
+        file_select => default:not_dir,
+        comment => "$(files[$(i)][why])";
+
+
+  reports:
+      # Run with --define DEBUG or --define delete_files:DEBUG for just this place!
+    DEBUG::
+
+      "WARNING: '$(this.namespace):$(this.bundle).files' is a singluar string, plausibly mis-configured"
+        if => strcmp( "$(_files_var_type)", "policy string" );
+
+      "$(this.namespace):$(this.bundle).files type = '$(_files_var_type)'";
+
+      "$(this.namespace):$(this.bundle).files contains mixed elements: $(with)"
+        with => join( ", ", getvalues( "_type" ) ),
+        if => and( not( strcmp( "1", length( unique( getvalues( "_type" ) ) ) ) ),
+                   not( strcmp( "$(_files_var_type)", "data object")));
+
+      "$(this.namespace):$(this.bundle).files is improperly defined as 'data object' expect 'data array'"
+        if => strcmp( "$(_files_var_type)", "data object" );
+
+      "$(this.namespace):$(this.bundle).files:$(const.n)$(with)"
+        with => storejson( "files" ),
+        if => or( strcmp( "$(_files_var_type)", "data array" ),
+                  strcmp( "$(_files_var_type)", "data object" ));
 }


### PR DESCRIPTION
This change adds support for more data structures defining the files that should
be deleted.

- A simple list of files is now supported
- A data array with a mix of strings and objects having path and why keys is now supported
- A simple string is now supported (but is likely indicative of a mis-configuration)
- A data array with objects lacking the why key is now supported.
- DEBUG reports were introduced, enabled by defining default:DEBUG or
  delete_files:DEBUG class.